### PR TITLE
angular $q wrapper

### DIFF
--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/Src/AngularModule.js.twig
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/Src/AngularModule.js.twig
@@ -5,6 +5,20 @@ import { TokenProvider, Scope } from 'paysera-http-client-common';
 import {{ type.name }} from './entity/{{ type.name }}';
 {% endfor %}
 
+{% import _self as macros %}
+{% macro render_wrap_q(resource, api) %}
+{% for subResource in resource.resources -%}
+{{ _self.render_wrap_q(subResource, api) -}}
+{% endfor %}
+{% for method in resource.methods -%}
+{% include '@PayseraJavascriptGenerator/Package/Src/Service/Method/wrap_q.js.twig' with {
+    'resource': resource,
+    'method': method,
+    'api': api
+} only -%}
+{% endfor %}
+{% endmacro -%}
+
 import DateFactory from './service/DateFactory';
 import ClientFactory from './service/ClientFactory';
 import {{ js_get_client_name(api.name) }} from './service/{{ js_get_client_name(api.name) }}';
@@ -19,6 +33,9 @@ export {
 };
 
 class AngularClientFactory {
+    constructor($q) {
+        this.$q = $q;
+    }
 
     /**
      * @param {object|null} config
@@ -43,9 +60,25 @@ class AngularClientFactory {
             factoryConfig.refreshTokenProvider = config.refreshTokenProvider;
         }
 
-        return ClientFactory.create(factoryConfig).get{{ js_get_client_name(api.name) }}(tokenProvider);
+        return this.wrapQ(
+            ClientFactory.create(factoryConfig).get{{ js_get_client_name(api.name) }}(tokenProvider)
+        );
+    }
+
+    /**
+     * @param {{ ('{' ~ js_get_client_name(api.name) ~ '}')|raw }} client
+     * @returns {{ ('{' ~ js_get_client_name(api.name) ~ '}')|raw }}
+     */
+    wrapQ(client) {
+{% for resource in api.ramlDefinition.resources -%}
+    {{ macros.render_wrap_q(resource, api) -}}
+{% endfor %}
+
+        return client;
     }
 }
+
+AngularClientFactory.$inject = ['$q'];
 
 export default angular
     .module('{{ js_get_angular_module_name(vendor_prefix, api.name) }}', [])

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/Src/Service/Method/wrap_q.js.twig
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/Src/Service/Method/wrap_q.js.twig
@@ -1,0 +1,4 @@
+        const {{ js_generate_method_name(method, resource) }}Original = client.{{ js_generate_method_name(method, resource) }}.bind(client);
+        client.{{ js_generate_method_name(method, resource) }} = (...args) => {
+            return this.$q.when({{ js_generate_method_name(method, resource) }}Original(...args));
+        }

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/category/src/angular.module.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/category/src/angular.module.js
@@ -17,6 +17,9 @@ export {
 };
 
 class AngularClientFactory {
+    constructor($q) {
+        this.$q = $q;
+    }
 
     /**
      * @param {object|null} config
@@ -41,9 +44,46 @@ class AngularClientFactory {
             factoryConfig.refreshTokenProvider = config.refreshTokenProvider;
         }
 
-        return ClientFactory.create(factoryConfig).getCategoryClient(tokenProvider);
+        return this.wrapQ(
+            ClientFactory.create(factoryConfig).getCategoryClient(tokenProvider)
+        );
+    }
+
+    /**
+     * @param {CategoryClient} client
+     * @returns {CategoryClient}
+     */
+    wrapQ(client) {
+        const enableCategoryOriginal = client.enableCategory.bind(client);
+        client.enableCategory = (...args) => {
+            return this.$q.when(enableCategoryOriginal(...args));
+        }
+        const disableCategoryOriginal = client.disableCategory.bind(client);
+        client.disableCategory = (...args) => {
+            return this.$q.when(disableCategoryOriginal(...args));
+        }
+        const updateCategoryOriginal = client.updateCategory.bind(client);
+        client.updateCategory = (...args) => {
+            return this.$q.when(updateCategoryOriginal(...args));
+        }
+        const deleteCategoryOriginal = client.deleteCategory.bind(client);
+        client.deleteCategory = (...args) => {
+            return this.$q.when(deleteCategoryOriginal(...args));
+        }
+        const getCategoriesOriginal = client.getCategories.bind(client);
+        client.getCategories = (...args) => {
+            return this.$q.when(getCategoriesOriginal(...args));
+        }
+        const createCategoryOriginal = client.createCategory.bind(client);
+        client.createCategory = (...args) => {
+            return this.$q.when(createCategoryOriginal(...args));
+        }
+
+        return client;
     }
 }
+
+AngularClientFactory.$inject = ['$q'];
 
 export default angular
     .module('vendor.http.category', [])

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/transfer/src/angular.module.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/transfer/src/angular.module.js
@@ -73,6 +73,9 @@ export {
 };
 
 class AngularClientFactory {
+    constructor($q) {
+        this.$q = $q;
+    }
 
     /**
      * @param {object|null} config
@@ -97,9 +100,66 @@ class AngularClientFactory {
             factoryConfig.refreshTokenProvider = config.refreshTokenProvider;
         }
 
-        return ClientFactory.create(factoryConfig).getTransferClient(tokenProvider);
+        return this.wrapQ(
+            ClientFactory.create(factoryConfig).getTransferClient(tokenProvider)
+        );
+    }
+
+    /**
+     * @param {TransferClient} client
+     * @returns {TransferClient}
+     */
+    wrapQ(client) {
+        const signTransferOriginal = client.signTransfer.bind(client);
+        client.signTransfer = (...args) => {
+            return this.$q.when(signTransferOriginal(...args));
+        }
+        const reserveTransferOriginal = client.reserveTransfer.bind(client);
+        client.reserveTransfer = (...args) => {
+            return this.$q.when(reserveTransferOriginal(...args));
+        }
+        const provideTransferPasswordOriginal = client.provideTransferPassword.bind(client);
+        client.provideTransferPassword = (...args) => {
+            return this.$q.when(provideTransferPasswordOriginal(...args));
+        }
+        const freezeTransferOriginal = client.freezeTransfer.bind(client);
+        client.freezeTransfer = (...args) => {
+            return this.$q.when(freezeTransferOriginal(...args));
+        }
+        const completeTransferOriginal = client.completeTransfer.bind(client);
+        client.completeTransfer = (...args) => {
+            return this.$q.when(completeTransferOriginal(...args));
+        }
+        const registerTransferOriginal = client.registerTransfer.bind(client);
+        client.registerTransfer = (...args) => {
+            return this.$q.when(registerTransferOriginal(...args));
+        }
+        const getTransferOriginal = client.getTransfer.bind(client);
+        client.getTransfer = (...args) => {
+            return this.$q.when(getTransferOriginal(...args));
+        }
+        const deleteTransferOriginal = client.deleteTransfer.bind(client);
+        client.deleteTransfer = (...args) => {
+            return this.$q.when(deleteTransferOriginal(...args));
+        }
+        const createTransferOriginal = client.createTransfer.bind(client);
+        client.createTransfer = (...args) => {
+            return this.$q.when(createTransferOriginal(...args));
+        }
+        const reserveTransfersOriginal = client.reserveTransfers.bind(client);
+        client.reserveTransfers = (...args) => {
+            return this.$q.when(reserveTransfersOriginal(...args));
+        }
+        const getTransfersOriginal = client.getTransfers.bind(client);
+        client.getTransfers = (...args) => {
+            return this.$q.when(getTransfersOriginal(...args));
+        }
+
+        return client;
     }
 }
+
+AngularClientFactory.$inject = ['$q'];
 
 export default angular
     .module('vendor.http.transfer', [])


### PR DESCRIPTION
If you use generated client in angular, $digest cycle is not called, so nothing is updated.
Now all client methods are wrapped with $q which runs $digest cycle(if it is not still running) and all code inside then(or other promise method) will be wrapped with $applyAsync.
