### PR TITLE
Fix missing file for release:clients command

### DIFF
--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
@@ -19,7 +19,7 @@ class GeneratePhpClientStep implements ReleaseStepInterface
         $releaseStepData->setGeneratedDir($releaseStepData->getTempDir() . '/generated');
 
         $args = [
-            'raml-code-generator',
+            'bin/raml-code-generator',
             'php-generator:rest-client',
             'raml_file' => $releaseStepData->getApiConfig()->getRamlFile(),
             'output_dir' => $releaseStepData->getGeneratedDir(),

--- a/tests/ClientReleaseBundle/RamlCodeGeneratorFileTest.php
+++ b/tests/ClientReleaseBundle/RamlCodeGeneratorFileTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\ClientReleaseBundle;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class RamlCodeGeneratorFileTest extends TestCase
+{
+    public function testFileExists()
+    {
+        // The `raml-code-generator` file location is hard-coded in the `processStep` method
+        // `src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php`.
+        // So, we only check for the existence of that file using process and arguments,
+        // otherwise the `release:clients` command will fail for missing file.
+        $process = new Process(['bin/raml-code-generator', '-h', '-q']);
+        $exitCode = $process->run();
+
+        $this->assertEquals(0, $exitCode, $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
The `release:clients` command was failing because `raml-code-generator` phar file was removed from the root directory. Instead an application command file was created at `bin/raml-code-generator`.

The file location in `src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php` is fixed.
Also, a simple test is added to check the existence of the required file and fail when the file is not in the expected location.