### PR TITLE
Fix for "exec: raml-code-generator: not found" error during release:clients

### DIFF
--- a/src/Paysera/Bundle/ClientReleaseBundle/Resources/config/services/release_steps.xml
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Resources/config/services/release_steps.xml
@@ -24,6 +24,7 @@
         <service id="paysera_client_release.release_step.generate_php_client"
                  class="Paysera\Bundle\ClientReleaseBundle\Service\ReleaseStep\GeneratePhpClientStep">
             <tag name="paysera_client_release.release_step" type="php" position="30"/>
+            <argument type="service" id="paysera_client_release.service.binary_path_resolver"/>
         </service>
 
         <service id="paysera_client_release.release_step.generate_js_client"

--- a/src/Paysera/Bundle/ClientReleaseBundle/Resources/config/services/services.xml
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Resources/config/services/services.xml
@@ -69,5 +69,14 @@
             <argument type="service" id="paysera_client_release.version_resolver.git_tag"/>
             <argument type="service" id="paysera_client_release.version_resolver.package_json"/>
         </service>
+
+        <service id="paysera_client_release.service.binary_path_resolver"
+                 class="Paysera\Bundle\ClientReleaseBundle\Service\BinaryPathResolver" >
+            <argument type="collection">
+                <argument type="string">%kernel.root_dir%/../bin</argument>
+                <argument type="string">%kernel.root_dir%/../dist</argument>
+            </argument>
+        </service>
+
     </services>
 </container>

--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/BinaryPathResolver.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/BinaryPathResolver.php
@@ -20,7 +20,8 @@ class BinaryPathResolver
     {
         foreach ($possibleBinaryNames as $binary) {
             $path = (new ExecutableFinder())
-                ->find($binary, null, $this->additionalLookupDirectories);
+                ->find($binary, null, $this->additionalLookupDirectories)
+            ;
 
             if ($path !== null) {
                 return $path;

--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/BinaryPathResolver.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/BinaryPathResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\Bundle\ClientReleaseBundle\Service;
+
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\ExecutableFinder;
+
+class BinaryPathResolver
+{
+    private $additionalLookupDirectories;
+
+    public function __construct(array $additionalLookupDirectories)
+    {
+        $this->additionalLookupDirectories = $additionalLookupDirectories;
+    }
+
+    public function getPath(array $possibleBinaryNames): string
+    {
+        foreach ($possibleBinaryNames as $binary) {
+            $path = (new ExecutableFinder())
+                ->find($binary, null, $this->additionalLookupDirectories);
+
+            if ($path !== null) {
+                return $path;
+            }
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Failed to find any of %s phar binary',
+                implode(',', $possibleBinaryNames)
+            )
+        );
+    }
+}

--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
@@ -6,15 +6,21 @@ namespace Paysera\Bundle\ClientReleaseBundle\Service\ReleaseStep;
 use Paysera\Bundle\ClientReleaseBundle\Entity\PhpClientDefinition;
 use Paysera\Bundle\ClientReleaseBundle\Entity\ReleaseStepData;
 use Paysera\Bundle\ClientReleaseBundle\Exception\ReleaseCycleException;
+use Paysera\Bundle\ClientReleaseBundle\Service\BinaryPathResolver;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Exception\RuntimeException;
-use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class GeneratePhpClientStep implements ReleaseStepInterface
 {
     const PHAR_FILE_NAME = 'raml-code-generator';
+
+    private $binaryPathResolver;
+
+    public function __construct(BinaryPathResolver $binaryPathResolver)
+    {
+        $this->binaryPathResolver = $binaryPathResolver;
+    }
 
     public function processStep(ReleaseStepData $releaseStepData, InputInterface $input, OutputInterface $output)
     {
@@ -23,7 +29,12 @@ class GeneratePhpClientStep implements ReleaseStepInterface
         $releaseStepData->setGeneratedDir($releaseStepData->getTempDir() . '/generated');
 
         $args = [
-            $this->findPharBinaryPath(),
+            $this->binaryPathResolver->getPath(
+                [
+                    self::PHAR_FILE_NAME,
+                    self::PHAR_FILE_NAME . '.phar',
+                ]
+            ),
             'php-generator:rest-client',
             'raml_file' => $releaseStepData->getApiConfig()->getRamlFile(),
             'output_dir' => $releaseStepData->getGeneratedDir(),
@@ -48,27 +59,5 @@ class GeneratePhpClientStep implements ReleaseStepInterface
             '<info>*</info> Generated PHP code for Api "%s"',
             $releaseStepData->getApiConfig()->getApiName()
         ));
-    }
-
-    private function findPharBinaryPath()
-    {
-        $localPath = $this->getCurrentDirectory() . '/bin/' . self::PHAR_FILE_NAME;
-        if (file_exists($localPath)) {
-            return $localPath;
-        }
-
-        $globalPath = (new ExecutableFinder())
-            ->find('raml-code-generator');
-
-        if ($globalPath === null) {
-            throw new RuntimeException('Failed to find phar binary');
-        }
-
-        return $globalPath;
-    }
-
-    private function getCurrentDirectory()
-    {
-        return str_replace('/bin', '', getcwd());
     }
 }

--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/GeneratePhpClientStep.php
@@ -8,10 +8,14 @@ use Paysera\Bundle\ClientReleaseBundle\Entity\ReleaseStepData;
 use Paysera\Bundle\ClientReleaseBundle\Exception\ReleaseCycleException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class GeneratePhpClientStep implements ReleaseStepInterface
 {
+    const PHAR_FILE_NAME = 'raml-code-generator';
+
     public function processStep(ReleaseStepData $releaseStepData, InputInterface $input, OutputInterface $output)
     {
         /** @var PhpClientDefinition $clientDefinition */
@@ -19,7 +23,7 @@ class GeneratePhpClientStep implements ReleaseStepInterface
         $releaseStepData->setGeneratedDir($releaseStepData->getTempDir() . '/generated');
 
         $args = [
-            'raml-code-generator',
+            $this->findPharBinaryPath(),
             'php-generator:rest-client',
             'raml_file' => $releaseStepData->getApiConfig()->getRamlFile(),
             'output_dir' => $releaseStepData->getGeneratedDir(),
@@ -44,5 +48,27 @@ class GeneratePhpClientStep implements ReleaseStepInterface
             '<info>*</info> Generated PHP code for Api "%s"',
             $releaseStepData->getApiConfig()->getApiName()
         ));
+    }
+
+    private function findPharBinaryPath()
+    {
+        $localPath = $this->getCurrentDirectory() . '/bin/' . self::PHAR_FILE_NAME;
+        if (file_exists($localPath)) {
+            return $localPath;
+        }
+
+        $globalPath = (new ExecutableFinder())
+            ->find('raml-code-generator');
+
+        if ($globalPath === null) {
+            throw new RuntimeException('Failed to find phar binary');
+        }
+
+        return $globalPath;
+    }
+
+    private function getCurrentDirectory()
+    {
+        return str_replace('/bin', '', getcwd());
     }
 }


### PR DESCRIPTION
Fixing the following issues during `release:clients` commands.

```
Failed to generate PHP client for Api "xxxxxx", error: sh: 1: exec: raml-code-generator: not found
```

- A new service `\Paysera\Bundle\ClientReleaseBundle\Service\BinaryPathResolver` created that is responsible to discover the phar binary path
- `\Symfony\Component\Process\ExecutableFinder` will find the executable globally as well as in `/bin` and `/dist` directory