### PR TITLE
`exec: raml-code-generator: not found` bug fixed for release:clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 11.4.2
+### Fixed
+- `exec: raml-code-generator: not found` bug fixed for `release:clients` command
+
 ## 11.4.1
 ### Changed
 - Fix generated php method return type when using annotation `(stream_response)`


### PR DESCRIPTION
Changelog updated for #103 (`exec: raml-code-generator: not found` bug fixed for `release:clients`)