### PR TITLE
Removed git clone timeout

### DIFF
--- a/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/CloneRepositoryStep.php
+++ b/src/Paysera/Bundle/ClientReleaseBundle/Service/ReleaseStep/CloneRepositoryStep.php
@@ -48,6 +48,7 @@ class CloneRepositoryStep implements ReleaseStepInterface
             ],
             $releaseStepData->getTempDir()
         );
+        $cloneProcess->setTimeout(null);
 
         $output->writeln('<info>*</info> Cloning repository...');
         $exitCode = $cloneProcess->run();


### PR DESCRIPTION
Fixes the timeout error which sometimes occurs on a slow connection:
```
 The process "'git' 'clone' 'ssh://git...' 'source'" exceeded the timeout of 60 seconds.
```