### PR TITLE
Changes for compatibility with typescript projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 11.8.0
+### Changed
+- exports for properties
+- methods types export to type declaration
+- library `paysera/lib-rest-client-common` version bump to 2.6.4
+
 ## 11.7.0
  - Added requirements to readme
  - Updated dependencies

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/config/services/type_configurations.xml
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/config/services/type_configurations.xml
@@ -39,7 +39,7 @@
                                     <argument type="string">@paysera/http-client-common</argument>
                                 </call>
                                 <call method="setVersion">
-                                    <argument type="string">^2.6</argument>
+                                    <argument type="string">^2.6.4</argument>
                                 </call>
                                 <call method="setOptions">
                                     <argument type="collection">
@@ -194,7 +194,7 @@
                                         <argument type="string">@paysera/http-client-common</argument>
                                     </call>
                                     <call method="setVersion">
-                                        <argument type="string">^2.6</argument>
+                                        <argument type="string">^2.6.4</argument>
                                     </call>
                                     <call method="setOptions">
                                         <argument type="collection">

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/index.d.ts.twig
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Resources/views/Package/index.d.ts.twig
@@ -14,13 +14,13 @@ import {{ typeConfig.importString|raw }};
         {% set extends = 'extends ' ~ get_parent_type_config(type).typeName ~ 'Properties ' %}
     {% endif %}
 {% endspaceless %}
-interface {{ typeConfig.typeName|extract_type_name }}Properties {{ extends }}{
+export interface {{ typeConfig.typeName|extract_type_name }}Properties {{ extends }}{
 {% for property in type.properties %}
     {{ property.name }}: {% include '@PayseraJavascriptGenerator/Package/Src/dts/get_getter_return_type.twig' with { 'property': property } only %};
 {% endfor %}
 }
 
-export interface {{ typeConfig.typeName|extract_type_name }} extends {{ get_parent_type_config(type).typeName }} {
+declare class {{ typeConfig.typeName|extract_type_name }} extends {{ get_parent_type_config(type).typeName }} {
 {% for property in type.properties %}
     {{ js_generate_getter_name(property) }}(): {% include '@PayseraJavascriptGenerator/Package/Src/dts/get_getter_return_type.twig' with { 'property': property } only %};
     {{ js_generate_setter_name(property) }}({% include '@PayseraJavascriptGenerator/Package/Src/dts/get_setter_argument.twig' with { 'property': property } only %}): this;


### PR DESCRIPTION
Due to updates in the `http client common` library, the version was bumped in the RAML generator to get proper types from extended instances such as `Entity`, `Filter` ,etc.

All exported client method types were changed to declarations because we have conflicts between module exports and type namings.