### PR TITLE
AC-2375: Complete Twig legacy-alias -> namespaced-class migration

### DIFF
--- a/src/Paysera/Bundle/CodeGeneratorBundle/Twig/BaseExtension.php
+++ b/src/Paysera/Bundle/CodeGeneratorBundle/Twig/BaseExtension.php
@@ -25,13 +25,12 @@ use Paysera\Component\StringHelper;
 use Raml\Body;
 use Raml\Method;
 use Raml\Resource;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 use Twig\TwigFunction;
-use Twig_Extension;
-use Twig_SimpleFilter;
-use Twig_SimpleFunction;
-use Twig_SimpleTest;
+use Twig\TwigTest;
 
-class BaseExtension extends Twig_Extension
+class BaseExtension extends AbstractExtension
 {
     const METHOD_NAME_OVERRIDE_ANNOTATION = '(generator_method_name_override)';
 
@@ -64,62 +63,62 @@ class BaseExtension extends Twig_Extension
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter(
+            new TwigFilter(
                 'to_variable_name',
                 [$this, 'getVariableNameByCodeType'],
                 ['needs_context' => true]
             ),
-            new Twig_SimpleFilter('to_class_name', [$this->stringConverter, 'convertSlugToClassName']),
-            new Twig_SimpleFilter('extract_type_name', [$this, 'extractTypeName']),
-            new Twig_SimpleFilter('to_kebab_case', [StringHelper::class, 'kebabCase']),
-            new Twig_SimpleFilter('to_snake_case', [StringHelper::class, 'snakeCase']),
-            new Twig_SimpleFilter('to_camel_case', [StringHelper::class, 'camelCase']),
-            new Twig_SimpleFilter('to_plural', [StringHelper::class, 'plural']),
-            new Twig_SimpleFilter('to_singular', [StringHelper::class, 'singular']),
-            new Twig_SimpleFilter('is_scalar_type', [$this, 'isScalarType']),
+            new TwigFilter('to_class_name', [$this->stringConverter, 'convertSlugToClassName']),
+            new TwigFilter('extract_type_name', [$this, 'extractTypeName']),
+            new TwigFilter('to_kebab_case', [StringHelper::class, 'kebabCase']),
+            new TwigFilter('to_snake_case', [StringHelper::class, 'snakeCase']),
+            new TwigFilter('to_camel_case', [StringHelper::class, 'camelCase']),
+            new TwigFilter('to_plural', [StringHelper::class, 'plural']),
+            new TwigFilter('to_singular', [StringHelper::class, 'singular']),
+            new TwigFilter('is_scalar_type', [$this, 'isScalarType']),
         ];
     }
 
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('is_discriminated', [$this, 'isDiscriminated']),
-            new Twig_SimpleFunction('get_constant_name', [$this, 'getConstantName']),
-            new Twig_SimpleFunction('is_result_type', [$this, 'isResultType']),
+            new TwigFunction('is_discriminated', [$this, 'isDiscriminated']),
+            new TwigFunction('get_constant_name', [$this, 'getConstantName']),
+            new TwigFunction('is_result_type', [$this, 'isResultType']),
 
-            new Twig_SimpleFunction('generate_method_name', [$this, 'generateMethodName']),
-            new Twig_SimpleFunction('generate_method_arguments', [$this, 'generateMethodArguments']),
-            new Twig_SimpleFunction('generate_body', [$this, 'generateBody']),
-            new Twig_SimpleFunction('is_raw_response', [$this, 'isRawResponse']),
-            new Twig_SimpleFunction('is_stream_response', [$this, 'isStreamResponse']),
-            new Twig_SimpleFunction('get_argument_names', [$this, 'getArgumentNames']),
-            new Twig_SimpleFunction('get_method_entity_name', [$this, 'getMethodEntityName']),
-            new Twig_SimpleFunction('method_returns_result', [$this, 'methodReturnsResult']),
-            new Twig_SimpleFunction('extract_filter_from_arguments', [$this, 'extractFilterFromArguments']),
-            new Twig_SimpleFunction('method_changes_state', [$this, 'methodChangesState']),
-            new Twig_SimpleFunction('flatten_resources', [$this, 'flattenResources']),
-            new Twig_SimpleFunction('flatten_sub_resources', [$this, 'flattenSubResources']),
-            new Twig_SimpleFunction('is_type_defined', [$this, 'isTypeDefined']),
-            new Twig_SimpleFunction('get_api_base_url_parameters_with_defaults', [$this, 'getApiBaseUrlParametersWithDefaults']),
+            new TwigFunction('generate_method_name', [$this, 'generateMethodName']),
+            new TwigFunction('generate_method_arguments', [$this, 'generateMethodArguments']),
+            new TwigFunction('generate_body', [$this, 'generateBody']),
+            new TwigFunction('is_raw_response', [$this, 'isRawResponse']),
+            new TwigFunction('is_stream_response', [$this, 'isStreamResponse']),
+            new TwigFunction('get_argument_names', [$this, 'getArgumentNames']),
+            new TwigFunction('get_method_entity_name', [$this, 'getMethodEntityName']),
+            new TwigFunction('method_returns_result', [$this, 'methodReturnsResult']),
+            new TwigFunction('extract_filter_from_arguments', [$this, 'extractFilterFromArguments']),
+            new TwigFunction('method_changes_state', [$this, 'methodChangesState']),
+            new TwigFunction('flatten_resources', [$this, 'flattenResources']),
+            new TwigFunction('flatten_sub_resources', [$this, 'flattenSubResources']),
+            new TwigFunction('is_type_defined', [$this, 'isTypeDefined']),
+            new TwigFunction('get_api_base_url_parameters_with_defaults', [$this, 'getApiBaseUrlParametersWithDefaults']),
 
 
-            new Twig_SimpleFunction('get_getter_method_template', [$this, 'getGetterMethodTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_setter_method_template', [$this, 'getSetterMethodTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_method_return_type_template', [$this, 'getMethodReturnTypeTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_method_argument_type_template', [$this, 'getMethodArgumentTypeTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_method_argument_typehint_template', [$this, 'getMethodArgumentTypeHintTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_property_normalizer_template', [$this, 'getPropertyNormalizerTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_property_denormalizer_template', [$this, 'getPropertyDenormalizerTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_entity_field_template', [$this, 'getEntityFieldTemplate'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_orm_field_template', [$this, 'getOrmFieldTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_getter_method_template', [$this, 'getGetterMethodTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_setter_method_template', [$this, 'getSetterMethodTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_method_return_type_template', [$this, 'getMethodReturnTypeTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_method_argument_type_template', [$this, 'getMethodArgumentTypeTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_method_argument_typehint_template', [$this, 'getMethodArgumentTypeHintTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_property_normalizer_template', [$this, 'getPropertyNormalizerTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_property_denormalizer_template', [$this, 'getPropertyDenormalizerTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_entity_field_template', [$this, 'getEntityFieldTemplate'], ['needs_context' => true]),
+            new TwigFunction('get_orm_field_template', [$this, 'getOrmFieldTemplate'], ['needs_context' => true]),
 
-            new Twig_SimpleFunction('get_type_definition', [$this, 'getTypeDefinition']),
-            new Twig_SimpleFunction('get_parent_type_config', [$this, 'getParentTypeConfig'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_related_types_config', [$this, 'getRelatedTypesConfig'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_external_libraries', [$this, 'getExternalLibrariesConfig'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_directly_used_types', [$this, 'getDirectlyUsedTypes'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_all_used_types', [$this, 'getAllUsedTypes'], ['needs_context' => true]),
-            new Twig_SimpleFunction('get_type_configuration', [$this, 'getTypeConfiguration'], ['needs_context' => true]),
+            new TwigFunction('get_type_definition', [$this, 'getTypeDefinition']),
+            new TwigFunction('get_parent_type_config', [$this, 'getParentTypeConfig'], ['needs_context' => true]),
+            new TwigFunction('get_related_types_config', [$this, 'getRelatedTypesConfig'], ['needs_context' => true]),
+            new TwigFunction('get_external_libraries', [$this, 'getExternalLibrariesConfig'], ['needs_context' => true]),
+            new TwigFunction('get_directly_used_types', [$this, 'getDirectlyUsedTypes'], ['needs_context' => true]),
+            new TwigFunction('get_all_used_types', [$this, 'getAllUsedTypes'], ['needs_context' => true]),
+            new TwigFunction('get_type_configuration', [$this, 'getTypeConfiguration'], ['needs_context' => true]),
             new TwigFunction('get_item_type_configuration', [$this, 'getItemTypeConfiguration'], ['needs_context' => true]),
         ];
     }
@@ -127,7 +126,7 @@ class BaseExtension extends Twig_Extension
     public function getTests()
     {
         return [
-            new Twig_SimpleTest('instanceof', [$this, 'isInstanceOf']),
+            new TwigTest('instanceof', [$this, 'isInstanceOf']),
         ];
     }
 

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Command/GeneratePackageCommand.php
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Command/GeneratePackageCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
-use Twig_Environment;
+use Twig\Environment;
 
 class GeneratePackageCommand extends Command
 {
@@ -26,7 +26,7 @@ class GeneratePackageCommand extends Command
         CodeGenerator $codeGenerator,
         Filesystem $filesystem,
         string $vendorPrefix,
-        Twig_Environment $twigEnvironment
+        Environment $twigEnvironment
     ) {
         parent::__construct();
 

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Twig/ApiMethodExtension.php
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Twig/ApiMethodExtension.php
@@ -19,10 +19,10 @@ use Paysera\Component\TypeHelper;
 use Raml\Method;
 use Raml\Resource;
 use Raml\Types\ArrayType;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class ApiMethodExtension extends Twig_Extension
+class ApiMethodExtension extends AbstractExtension
 {
     private $stringConverter;
     private $bodyResolver;
@@ -44,19 +44,19 @@ class ApiMethodExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('js_get_client_name', [$this, 'getClientName']),
-            new Twig_SimpleFunction('js_get_package_name', [$this, 'getPackageName']),
-            new Twig_SimpleFunction('js_get_package_version', [$this, 'getPackageVersion']),
-            new Twig_SimpleFunction('js_get_platform_version', [$this, 'getPlatformVersion']),
-            new Twig_SimpleFunction('js_get_angular_module_name', [$this, 'getAngularJsModuleName'], ['is_safe' => ['js']]),
-            new Twig_SimpleFunction('js_get_angular_client_factory_name', [$this, 'getAngularJsFactoryClassName']),
-            new Twig_SimpleFunction('js_generate_uri', [$this, 'generateUri'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('js_generate_result_populator', [$this, 'generateResultPopulator'], [
+            new TwigFunction('js_get_client_name', [$this, 'getClientName']),
+            new TwigFunction('js_get_package_name', [$this, 'getPackageName']),
+            new TwigFunction('js_get_package_version', [$this, 'getPackageVersion']),
+            new TwigFunction('js_get_platform_version', [$this, 'getPlatformVersion']),
+            new TwigFunction('js_get_angular_module_name', [$this, 'getAngularJsModuleName'], ['is_safe' => ['js']]),
+            new TwigFunction('js_get_angular_client_factory_name', [$this, 'getAngularJsFactoryClassName']),
+            new TwigFunction('js_generate_uri', [$this, 'generateUri'], ['is_safe' => ['html']]),
+            new TwigFunction('js_generate_result_populator', [$this, 'generateResultPopulator'], [
                 'is_safe' => ['html'],
                 'needs_context' => true,
             ]),
-            new Twig_SimpleFunction('js_get_return_type', [$this, 'getReturnType']),
-            new Twig_SimpleFunction('js_get_related_types', [$this, 'getRelatedTypes']),
+            new TwigFunction('js_get_return_type', [$this, 'getReturnType']),
+            new TwigFunction('js_get_related_types', [$this, 'getRelatedTypes']),
         ];
     }
 

--- a/src/Paysera/Bundle/JavascriptGeneratorBundle/Twig/FieldDefinitionExtension.php
+++ b/src/Paysera/Bundle/JavascriptGeneratorBundle/Twig/FieldDefinitionExtension.php
@@ -8,10 +8,10 @@ use Paysera\Bundle\CodeGeneratorBundle\Entity\Definition\DateTimeTypeDefinition;
 use Paysera\Bundle\CodeGeneratorBundle\Entity\Definition\PropertyDefinition;
 use Paysera\Bundle\CodeGeneratorBundle\Service\TypeConfigurationProvider;
 use Paysera\Bundle\CodeGeneratorBundle\Service\StringConverter;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class FieldDefinitionExtension extends Twig_Extension
+class FieldDefinitionExtension extends AbstractExtension
 {
     const DATETIME_INSTANCE = 'Date';
 
@@ -29,10 +29,10 @@ class FieldDefinitionExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('js_generate_getter_name', [$this, 'getGetterName']),
-            new Twig_SimpleFunction('js_generate_setter_name', [$this, 'getSetterName']),
-            new Twig_SimpleFunction('js_extract_type_name', [$this, 'extractTypeName']),
-            new Twig_SimpleFunction('js_resolve_date_type_format', [$this, 'resolveDateTypeFormat']),
+            new TwigFunction('js_generate_getter_name', [$this, 'getGetterName']),
+            new TwigFunction('js_generate_setter_name', [$this, 'getSetterName']),
+            new TwigFunction('js_extract_type_name', [$this, 'extractTypeName']),
+            new TwigFunction('js_resolve_date_type_format', [$this, 'resolveDateTypeFormat']),
         ];
     }
 

--- a/src/Paysera/Bundle/PhpGeneratorBundle/Command/GenerateRestClientCommand.php
+++ b/src/Paysera/Bundle/PhpGeneratorBundle/Command/GenerateRestClientCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class GenerateRestClientCommand extends Command
 {
@@ -19,7 +19,7 @@ class GenerateRestClientCommand extends Command
 
     public function __construct(
         CodeGenerator $codeGenerator,
-        Twig_Environment $twigEnvironment
+        Environment $twigEnvironment
     ) {
         parent::__construct();
 

--- a/src/Paysera/Bundle/PhpGeneratorBundle/Command/GenerateSymfonyBundleCommand.php
+++ b/src/Paysera/Bundle/PhpGeneratorBundle/Command/GenerateSymfonyBundleCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class GenerateSymfonyBundleCommand extends Command
 {
@@ -18,7 +18,7 @@ class GenerateSymfonyBundleCommand extends Command
 
     public function __construct(
         CodeGenerator $codeGenerator,
-        Twig_Environment $twigEnvironment
+        Environment $twigEnvironment
     ) {
         parent::__construct();
 

--- a/src/Paysera/Bundle/PhpGeneratorBundle/Twig/ApiMethodExtension.php
+++ b/src/Paysera/Bundle/PhpGeneratorBundle/Twig/ApiMethodExtension.php
@@ -18,11 +18,11 @@ use Psr\Http\Message\StreamInterface;
 use Raml\Method;
 use Raml\Resource;
 use Raml\Types\ArrayType;
-use Twig_Extension;
-use Twig_SimpleFilter;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
-class ApiMethodExtension extends Twig_Extension
+class ApiMethodExtension extends AbstractExtension
 {
     private $bodyResolver;
     private $baseExtension;
@@ -47,27 +47,27 @@ class ApiMethodExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('php_generate_uri', [$this, 'generateUri'], ['is_safe' => ['html']]),
-            new Twig_SimpleFunction('php_generate_result_populator', [$this, 'generateResultPopulator'], [
+            new TwigFunction('php_generate_uri', [$this, 'generateUri'], ['is_safe' => ['html']]),
+            new TwigFunction('php_generate_result_populator', [$this, 'generateResultPopulator'], [
                 'is_safe' => ['html'],
                 'needs_context' => true,
             ]),
-            new Twig_SimpleFunction('php_inline_arguments', [$this, 'inlineArguments']),
-            new Twig_SimpleFunction('php_inline_arguments_no_typehint', [$this, 'inlineArgumentsNoTypehint']),
-            new Twig_SimpleFunction('php_get_return_type', [$this, 'getReturnType'], ['needs_context' => true]),
-            new Twig_SimpleFunction('php_generate_method_arguments', [$this, 'generateMethodArguments'], ['needs_context' => true]),
-            new Twig_SimpleFunction('php_inline_argument_names', [$this, 'getInlineArgumentNames']),
-            new Twig_SimpleFunction('php_get_library_name', [$this, 'getLibraryName']),
-            new Twig_SimpleFunction('php_get_library_version', [$this, 'getLibraryVersion']),
-            new Twig_SimpleFunction('php_get_platform_version', [$this, 'getPlatformVersion']),
-            new Twig_SimpleFunction('php_generate_entity_converter', [$this, 'generateEntityFromArgument'], ['needs_context' => true, 'is_safe' => ['html']]),
+            new TwigFunction('php_inline_arguments', [$this, 'inlineArguments']),
+            new TwigFunction('php_inline_arguments_no_typehint', [$this, 'inlineArgumentsNoTypehint']),
+            new TwigFunction('php_get_return_type', [$this, 'getReturnType'], ['needs_context' => true]),
+            new TwigFunction('php_generate_method_arguments', [$this, 'generateMethodArguments'], ['needs_context' => true]),
+            new TwigFunction('php_inline_argument_names', [$this, 'getInlineArgumentNames']),
+            new TwigFunction('php_get_library_name', [$this, 'getLibraryName']),
+            new TwigFunction('php_get_library_version', [$this, 'getLibraryVersion']),
+            new TwigFunction('php_get_platform_version', [$this, 'getPlatformVersion']),
+            new TwigFunction('php_generate_entity_converter', [$this, 'generateEntityFromArgument'], ['needs_context' => true, 'is_safe' => ['html']]),
         ];
     }
 
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter('php_unique_arguments_by_namespace', [$this, 'getUniqueArgumentsByNamespace']),
+            new TwigFilter('php_unique_arguments_by_namespace', [$this, 'getUniqueArgumentsByNamespace']),
         ];
     }
 

--- a/src/Paysera/Bundle/PhpGeneratorBundle/Twig/BundleExtension.php
+++ b/src/Paysera/Bundle/PhpGeneratorBundle/Twig/BundleExtension.php
@@ -28,11 +28,11 @@ use Raml\Method;
 use Raml\NamedParameter;
 use Raml\Resource;
 use Symfony\Component\HttpFoundation\Response;
-use Twig_Extension;
-use Twig_SimpleFilter;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
-class BundleExtension extends Twig_Extension
+class BundleExtension extends AbstractExtension
 {
     private $typeConfigurationProvider;
     private $bodyResolver;
@@ -66,14 +66,14 @@ class BundleExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('symfony_bundle_get_normalizer_constructor_args', [$this, 'getNormalizerConstructorArguments']),
-            new Twig_SimpleFunction('symfony_bundle_type_has_collection', [$this, 'typeHasCollection']),
-            new Twig_SimpleFunction('symfony_bundle_get_return_type', [$this, 'getReturnType']),
-            new Twig_SimpleFunction('symfony_bundle_get_response_type', [$this, 'getResponseType']),
-            new Twig_SimpleFunction('symfony_bundle_get_directly_used_types_in_sub_resource', [$this, 'getDirectlyUsedTypesInSubResource']),
-            new Twig_SimpleFunction('symfony_bundle_get_controller_constructor_args', [$this, 'getControllerConstructorArgs']),
-            new Twig_SimpleFunction('symfony_bundle_generate_method_arguments', [$this, 'generateMethodArguments'], ['needs_context' => true]),
-            new Twig_SimpleFunction('symfony_bundle_get_api_base_url_parameters_with_defaults', [$this, 'getApiBaseUrlParametersWithDefaults']),
+            new TwigFunction('symfony_bundle_get_normalizer_constructor_args', [$this, 'getNormalizerConstructorArguments']),
+            new TwigFunction('symfony_bundle_type_has_collection', [$this, 'typeHasCollection']),
+            new TwigFunction('symfony_bundle_get_return_type', [$this, 'getReturnType']),
+            new TwigFunction('symfony_bundle_get_response_type', [$this, 'getResponseType']),
+            new TwigFunction('symfony_bundle_get_directly_used_types_in_sub_resource', [$this, 'getDirectlyUsedTypesInSubResource']),
+            new TwigFunction('symfony_bundle_get_controller_constructor_args', [$this, 'getControllerConstructorArgs']),
+            new TwigFunction('symfony_bundle_generate_method_arguments', [$this, 'generateMethodArguments'], ['needs_context' => true]),
+            new TwigFunction('symfony_bundle_get_api_base_url_parameters_with_defaults', [$this, 'getApiBaseUrlParametersWithDefaults']),
 
         ];
     }
@@ -81,8 +81,8 @@ class BundleExtension extends Twig_Extension
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter('symfony_bundle_unique_arguments', [$this, 'getUniqueArguments']),
-            new Twig_SimpleFilter('symfony_bundle_unique_array_types', [$this, 'getUniqueArrayTypes']),
+            new TwigFilter('symfony_bundle_unique_arguments', [$this, 'getUniqueArguments']),
+            new TwigFilter('symfony_bundle_unique_array_types', [$this, 'getUniqueArrayTypes']),
         ];
     }
 

--- a/src/Paysera/Bundle/PhpGeneratorBundle/Twig/FieldDefinitionExtension.php
+++ b/src/Paysera/Bundle/PhpGeneratorBundle/Twig/FieldDefinitionExtension.php
@@ -7,10 +7,10 @@ use Paysera\Bundle\CodeGeneratorBundle\Entity\Definition\DateTimeTypeDefinition;
 use Paysera\Bundle\CodeGeneratorBundle\Entity\Definition\PropertyDefinition;
 use Paysera\Bundle\CodeGeneratorBundle\Exception\UnrecognizedTypeException;
 use Paysera\Bundle\CodeGeneratorBundle\Service\StringConverter;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class FieldDefinitionExtension extends Twig_Extension
+class FieldDefinitionExtension extends AbstractExtension
 {
     private $stringConverter;
 
@@ -23,9 +23,9 @@ class FieldDefinitionExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('php_generate_getter_name', [$this, 'generateGetterName']),
-            new Twig_SimpleFunction('php_generate_setter_name', [$this, 'generateSetterName']),
-            new Twig_SimpleFunction('php_resolve_date_type_format', [$this, 'resolveDateTypeFormat']),
+            new TwigFunction('php_generate_getter_name', [$this, 'generateGetterName']),
+            new TwigFunction('php_generate_setter_name', [$this, 'generateSetterName']),
+            new TwigFunction('php_resolve_date_type_format', [$this, 'resolveDateTypeFormat']),
         ];
     }
 


### PR DESCRIPTION
Jira: [AC-2375](https://jira.paysera.net/browse/AC-2375)

## Why

The `Twig_*` legacy aliases are **removed in Twig 3**, so any Twig 3 / Symfony 4+ upgrade of this repo cannot even compile until they are gone. The migration was started earlier and abandoned midway: `BaseExtension::getFunctions()` had one modern `new TwigFunction(...)` sitting directly beside 33 legacy `new Twig_SimpleFunction(...)` calls. This PR completes it. No upgrade is involved — `twig/twig ^2.12` (resolved: **v2.16.1** on a fresh `composer install` with Composer 2.2.9 / PHP 7.4.33) already ships the namespaced API; the legacy names are `class_alias`es of the exact classes substituted (verified in vendor sources: `AbstractExtension.php:47`, `TwigFilter.php:145`, `TwigFunction.php:135`, `TwigTest.php:113`, `Environment.php:994`).

## Exact mechanical mapping

| Legacy alias | Namespaced class | Where |
|---|---|---|
| `Twig_Extension` (extends) | `Twig\Extension\AbstractExtension` | 6 extension classes |
| `new Twig_SimpleFilter(` | `new Twig\TwigFilter(` | 11 call sites |
| `new Twig_SimpleFunction(` | `new Twig\TwigFunction(` | 62 call sites |
| `new Twig_SimpleTest(` | `new Twig\TwigTest(` | 1 call site |
| `Twig_Environment` (type-hint) | `Twig\Environment` | 3 Command classes |

Files: `CodeGeneratorBundle/Twig/BaseExtension`, `PhpGeneratorBundle/Twig/{BundleExtension, ApiMethodExtension, FieldDefinitionExtension}`, `JavascriptGeneratorBundle/Twig/{ApiMethodExtension, FieldDefinitionExtension}`, plus the 3 commands below.

**⚠️ Verifier-added scope (flagged for the human reviewer):** the original task covered only the 6 extension classes. The plan verifier added `Twig_Environment` → `Twig\Environment` in the 3 Command classes (`GenerateRestClientCommand`, `GenerateSymfonyBundleCommand`, `GeneratePackageCommand`) — also removed in Twig 3, constructor type-hint + `use` line only. The injected `twig` service instance is the same object; DI needs no change (all three service XMLs register the extensions by their own Paysera FQCN).

All option arrays preserved verbatim — 23 `['needs_context' => true]` occurrences across the 6 files (17 in BaseExtension), and both `'is_safe'` flags. Nothing else touched: no composer.json/lock edits, no DI, no templates, no fixtures.

## Proof (byte-identical output)

- **Baseline before any edit:** `bin/phpunit` (PHPUnit 9.6.34, PHP 7.4.33 in Docker) → `OK (42 tests, 1736 assertions)`.
- **After migration:** same suite → `OK (42 tests, 1736 assertions)`. The three golden-master tests (`GenerateRestClientCommandTest`, `GenerateSymfonyBundleCommandTest`, `GeneratePackageCommandTest`) compare generated output against the **910 fixture files** under `tests/**/Fixtures` — all byte-identical, `git status` on tests/ clean.
- **Direct dynamic proof:** `bin/console php-generator:rest-client` run on the `account` RAML fixture before and after the change into separate directories; `diff -r` of the two trees (9 generated files) → **empty**.
- **Legacy grep:** `git grep -E 'Twig_(Extension|SimpleFilter|SimpleFunction|SimpleTest|Environment)' -- ':!vendor'` → zero matches.
- **CI steps pre-run locally** in the same PHP 7.4 container: `bin/phpunit` ✓, `bin/raml-code-generator` ✓, `composer run compile` (box) ✓, `dist/raml-code-generator.phar` smoke ✓. The GitHub Actions `CI` workflow runs on this PR and must end green.

Draft on purpose (blast radius: medium — touches the core generation path); please review before marking ready.
