### PR TITLE
TR-7946 Generate nullable union types instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## 11.13.0
+### Added
+- Nullable union types (`X | nil`) are now generated as the underlying type instead of aborting generation, both for property types and for array item types. A union of two value types is still refused, because it has no single representation to generate
+
 ## 11.11.5
 ### Fixed
 - Fixes PHP client generation issue by fixing Money object array hydration

--- a/src/Paysera/Bundle/CodeGeneratorBundle/Service/PropertyDefinitionBuilder.php
+++ b/src/Paysera/Bundle/CodeGeneratorBundle/Service/PropertyDefinitionBuilder.php
@@ -20,6 +20,8 @@ class PropertyDefinitionBuilder
 
     public function buildPropertyDefinition(string $name, array $definition)
     {
+        $definition = $this->resolveNullableUnions($definition);
+
         $property = $this->getPropertyDefinition($definition);
 
         $property
@@ -58,6 +60,45 @@ class PropertyDefinitionBuilder
         }
 
         return $property;
+    }
+
+    /**
+     * `X | nil` states that a property is present but may hold no value. That is nullability, not a
+     * choice between two shapes, and every generated getter already returns null when the key is
+     * absent — so the union collapses to `X` with nothing lost.
+     *
+     * A union of two real types (`string | boolean`) is a different thing entirely: it has no single
+     * representation to generate, so it is deliberately left alone to fail loudly.
+     */
+    private function resolveNullableUnions(array $definition): array
+    {
+        if (isset($definition['type']) && is_string($definition['type'])) {
+            $definition['type'] = $this->resolveNullableUnion($definition['type']);
+        }
+
+        if (isset($definition['items']['type']) && is_string($definition['items']['type'])) {
+            $definition['items']['type'] = $this->resolveNullableUnion($definition['items']['type']);
+        }
+
+        return $definition;
+    }
+
+    private function resolveNullableUnion(string $type): string
+    {
+        if (strpos($type, '|') === false) {
+            return $type;
+        }
+
+        $members = array_map('trim', explode('|', $type));
+        $valueTypes = array_values(array_filter($members, static function (string $member) {
+            return !in_array(strtolower($member), ['nil', 'null'], true);
+        }));
+
+        if (count($valueTypes) !== 1 || count($valueTypes) === count($members)) {
+            return $type;
+        }
+
+        return $valueTypes[0];
     }
 
     private function getPropertyDefinition(array $definition)

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.babelrc.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.babelrc.js
@@ -1,0 +1,10 @@
+module.exports = (api) => {
+    api.cache.forever();
+
+    return {
+        presets: [
+            ['@babel/preset-env', { modules: false }],
+        ],
+        plugins: ['@babel/plugin-transform-runtime'],
+    };
+};

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.eslintrc.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    env: {
+        browser: true,
+    },
+    parser: 'babel-eslint',
+    'extends': [
+        '@paysera',
+    ],
+};

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.gitignore
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/README.md
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/README.md
@@ -1,0 +1,43 @@
+# @vendor/nullable-union-client
+
+`@vendor/nullable-union-client` package provides means to interact with Vendor NullableUnionClient REST API.
+Package source code is written in ES6 syntax ant is transpiled to ES5 using babel.
+
+## Installing
+Using npm:
+```bash
+$ npm install @vendor/nullable-union-client
+```
+
+Using javascript files
+```html
+<script src="//domain.com/path/to/@paysera/http-client-common/dist/main.js"></script>
+<script src="//domain.com/path/to/@vendor/nullable-union-client/dist/lib.js"></script>
+```
+
+# Usage
+```js
+import {
+    createClient,
+    createRequest,
+    JWTAuthenticationMiddleware,
+    SessionStorageTokenProvider,
+    Scope,
+} from '@paysera/http-client-common';
+import { createNullableUnionClient } from '@vendor/nullable-union-client';
+
+const client = createNullableUnionClient({
+    baseUrl: 'http://sandbox.domain.com/', // optional, custom base url
+    middleware: [ // optional, list of middleware
+        new JWTAuthenticationMiddleware(
+            new Scope('scope:a'),
+            new SessionStorageTokenProvider(
+                (scope) => ({ scope, accessToken: 'created-token' }),
+                (scope) => ({ scope, accessToken: 'refreshed-token' }),
+                'nullable_union_client', // unique identifier of token
+                'NullableUnionClient', // storage namespace
+            ),
+        ),
+    ]
+});
+```

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/index.d.ts
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/index.d.ts
@@ -1,0 +1,61 @@
+import { Entity } from '@paysera/http-client-common';
+
+export interface OrderProperties {
+    id: string;
+    note: string;
+    discount: string | null;
+    line: OrderLine | null;
+    tags: string[] | null;
+    lines: OrderLine[] | null;
+}
+
+declare class Order extends Entity {
+    getId(): string;
+    setId(id: string): this;
+    getNote(): string;
+    setNote(note: string): this;
+    getDiscount(): string | null;
+    setDiscount(discount: string | null): this;
+    getLine(): OrderLine | null;
+    setLine(line: OrderLine | null): this;
+    getTags(): string[] | null;
+    setTags(tags: string[] | null): this;
+    getLines(): OrderLine[] | null;
+    setLines(lines: OrderLine[] | null): this;
+
+    getData(): OrderProperties;
+}
+
+export interface OrderLineProperties {
+    sku: string;
+    quantity: bigint;
+}
+
+declare class OrderLine extends Entity {
+    getSku(): string;
+    setSku(sku: string): this;
+    getQuantity(): bigint;
+    setQuantity(quantity: bigint): this;
+
+    getData(): OrderLineProperties;
+}
+
+
+interface ClientConfigurationOptions {
+    urlParameters?: {
+        [key: string]: string,
+    },
+    [key: string]: any,
+}
+
+interface ClientConfiguration {
+    baseURL: string,
+    middleware?: object[],
+    options?: ClientConfigurationOptions
+}
+
+export function createNullableUnionClient(configuration: ClientConfiguration): NullableUnionClient;
+
+export interface NullableUnionClient {
+    createOrder(order: Order): Promise<Order>
+}

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/package.json
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@vendor/nullable-union-client",
+    "version": "0.0.1",
+    "author": "vendor",
+    "main": "dist/umd/main.js",
+    "module": "dist/es/index.js",
+    "types": "index.d.ts",
+    "files": [
+        "index.d.ts",
+        "dist",
+        "src"
+    ],
+    "scripts": {
+        "clean": "rimraf dist",
+        "build": "npm run clean && npm run build:umd && npm run build:es",
+        "build:umd": "webpack --mode production",
+        "build:es": "babel ./src --out-dir ./dist/es",
+        "prepublishOnly": "npm run build",
+        "lint": "eslint src/**/*.js"
+    },
+    "dependencies": {
+        "@babel/runtime": "^7.12.10",
+        "@paysera/http-client-common": "^2.6.4"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.12.10",
+        "@babel/core": "^7.12.10",
+        "@babel/plugin-transform-runtime": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "@paysera/eslint-config": "^1.2.0",
+        "babel-eslint": "^11.0.0-beta.2",
+        "babel-loader": "^8.2.2",
+        "eslint": "^7.17.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-jsx-a11y": "^6.4.1",
+        "eslint-plugin-react": "^7.22.0",
+        "rimraf": "^3.0.2",
+        "webpack": "^5.11.1",
+        "webpack-cli": "^4.3.1"
+    }
+}

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/entity/Order.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/entity/Order.js
@@ -1,0 +1,111 @@
+import OrderLine from './OrderLine';
+import { Entity } from '@paysera/http-client-common';
+
+class Order extends Entity {
+    constructor(data = {}) {
+        super(data);
+    }
+
+    /**
+     * @return {string}
+     */
+    getId() {
+        return this.get('id');
+    }
+
+    /**
+     * @param {string} id
+     */
+    setId(id) {
+        this.set('id', id);
+    }
+
+    /**
+     * @return {string}
+     */
+    getNote() {
+        return this.get('note');
+    }
+
+    /**
+     * @param {string} note
+     */
+    setNote(note) {
+        this.set('note', note);
+    }
+
+    /**
+     * @return {string|null}
+     */
+    getDiscount() {
+        return this.get('discount');
+    }
+
+    /**
+     * @param {string} discount
+     */
+    setDiscount(discount) {
+        this.set('discount', discount);
+    }
+
+    /**
+     * @return {OrderLine|null}
+     */
+    getLine() {
+        if (this.get('line') == null) {
+            return null;
+        }
+        return new OrderLine(this.get('line'));
+    }
+
+    /**
+     * @param {OrderLine} line
+     */
+    setLine(line) {
+        this.set('line', line.getData());
+    }
+
+    /**
+     * @return {Array.<string>|null}
+     */
+    getTags() {
+        return this.get('tags');
+    }
+
+    /**
+     * @param {Array.<string>} tags
+     */
+    setTags(tags) {
+        this.set('tags', tags);
+    }
+
+    /**
+     * @return {Array.<OrderLine>}
+     */
+    getLines() {
+        let data = this.get('lines');
+        if (data === null) {
+            return [];
+        }
+
+        let collection = [];
+        for (let value of data) {
+            collection.push(new OrderLine(value));
+        }
+
+        return collection;
+    }
+
+    /**
+     * @param {Array.<OrderLine>} lines
+     */
+    setLines(lines) {
+        let data = [];
+        for (let entity of lines) {
+            data.push(entity.getData());
+        }
+        this.set('lines', data);
+    }
+}
+
+export default Order;

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/entity/OrderLine.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/entity/OrderLine.js
@@ -1,0 +1,37 @@
+import { Entity } from '@paysera/http-client-common';
+
+class OrderLine extends Entity {
+    constructor(data = {}) {
+        super(data);
+    }
+
+    /**
+     * @return {string}
+     */
+    getSku() {
+        return this.get('sku');
+    }
+
+    /**
+     * @param {string} sku
+     */
+    setSku(sku) {
+        this.set('sku', sku);
+    }
+
+    /**
+     * @return {Number}
+     */
+    getQuantity() {
+        return this.get('quantity');
+    }
+
+    /**
+     * @param {Number} quantity
+     */
+    setQuantity(quantity) {
+        this.set('quantity', quantity);
+    }
+}
+
+export default OrderLine;

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/index.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/index.js
@@ -1,0 +1,14 @@
+import Order from './entity/Order';
+import OrderLine from './entity/OrderLine';
+import { Entity } from '@paysera/http-client-common';
+
+import { createNullableUnionClient } from './service/createClient';
+import NullableUnionClient from './service/NullableUnionClient';
+
+export {
+    Order,
+    OrderLine,
+    Entity,
+    createNullableUnionClient,
+    NullableUnionClient,
+};

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/service/NullableUnionClient.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/service/NullableUnionClient.js
@@ -1,0 +1,34 @@
+import { createRequest, ClientWrapper } from '@paysera/http-client-common';
+
+import Order from '../entity/Order';
+
+class NullableUnionClient {
+    /**
+     * @param {ClientWrapper} client
+     */
+    constructor(client) {
+        this.client = client;
+    }
+
+    /**
+     * Create order
+     * POST /orders
+     *
+     * @param {Order} order
+     * @return {Promise.<Order>}
+     */
+    createOrder(order) {
+        const request = createRequest(
+            'POST',
+            `orders`,
+            order,
+        );
+
+        return this.client
+            .performRequest(request)
+            .then(data => new Order(data));
+    }
+
+}
+
+export default NullableUnionClient;

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/service/createClient.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/src/service/createClient.js
@@ -1,0 +1,36 @@
+import { createClient } from '@paysera/http-client-common';
+import NullableUnionClient from './NullableUnionClient';
+
+/**
+ * @param {string} baseURL
+ * @param {[]|null} middleware
+ * @param {object} options
+ *
+ * @returns {NullableUnionClient}
+ */
+/* eslint import/prefer-default-export: ["off"] */
+export const createNullableUnionClient = ({
+    baseURL = 'https://my-api.example.com/rest/v1/',
+    middleware = null,
+    options = {}
+}) => {
+    const defaultUrlParameters = {};
+    
+    if (Object.prototype.hasOwnProperty.call(options, 'urlParameters')) {
+        const { urlParameters } = options;
+        for (let [key, value] of Object.entries(defaultUrlParameters)) {
+            if (!Object.prototype.hasOwnProperty.call(urlParameters, key)) {
+                urlParameters[key] = value;
+            }
+        }
+        options.urlParameters = urlParameters;
+    }
+
+    return new NullableUnionClient(
+        createClient({
+            baseURL,
+            middleware,
+            options
+        })
+    )
+};

--- a/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/webpack.config.js
+++ b/tests/JavascriptGeneratorBundle/Fixtures/expected/nullable-union/webpack.config.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+module.exports = () => {
+    const config = {
+        entry: {
+            index: path.resolve(__dirname, 'src/index.js'),
+        },
+        output: {
+            path: path.resolve(__dirname, 'dist/umd'),
+            filename: 'main.js',
+            libraryTarget: 'umd',
+            library: 'vendorNullableUnionClient'
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.jsx?$/,
+                    exclude: /node_modules/,
+                    loader: 'babel-loader'
+                }
+            ],
+        },
+        devtool: 'source-map',
+        externals: {
+            '@paysera/http-client-common': {
+                'root': 'PayseraHttpClientCommon',
+                'commonjs': '@paysera/http-client-common',
+                'commonjs2': '@paysera/http-client-common',
+                'amd': '@paysera/http-client-common',
+            },
+        },
+        resolve: {
+            extensions: ['.js', '.jsx'],
+        },
+    };
+
+    return config;
+};

--- a/tests/JavascriptGeneratorBundle/Fixtures/raml/genuine-union/api.raml
+++ b/tests/JavascriptGeneratorBundle/Fixtures/raml/genuine-union/api.raml
@@ -1,0 +1,26 @@
+#%RAML 1.0
+title: Genuine Union API
+version: v1
+baseUri: https://my-api.example.com/rest/v1
+mediaType: application/json
+protocols: [ HTTPS ]
+
+uses:
+  Paysera: ../__library/rest.raml
+
+types:
+  Setting: !include types/setting.raml
+
+/settings:
+  post:
+    description: Create setting
+    body:
+      application/json:
+        displayName: body
+        type: Setting
+    responses:
+      200:
+        description: Item response
+        body:
+          application/json:
+            type: Setting

--- a/tests/JavascriptGeneratorBundle/Fixtures/raml/genuine-union/types/setting.raml
+++ b/tests/JavascriptGeneratorBundle/Fixtures/raml/genuine-union/types/setting.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 DataType
+type: object
+displayName: Setting object
+properties:
+  id:
+    type: string
+    required: true
+  value:
+    type: string | boolean
+    required: true
+    description: A union of two value types, which has no single representation

--- a/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/api.raml
+++ b/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/api.raml
@@ -1,0 +1,27 @@
+#%RAML 1.0
+title: Nullable Union API
+version: v1
+baseUri: https://my-api.example.com/rest/v1
+mediaType: application/json
+protocols: [ HTTPS ]
+
+uses:
+  Paysera: ../__library/rest.raml
+
+types:
+  OrderLine: !include types/order-line.raml
+  Order: !include types/order.raml
+
+/orders:
+  post:
+    description: Create order
+    body:
+      application/json:
+        displayName: body
+        type: Order
+    responses:
+      200:
+        description: Item response
+        body:
+          application/json:
+            type: Order

--- a/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/types/order-line.raml
+++ b/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/types/order-line.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+type: object
+displayName: Order Line
+properties:
+  sku:
+    type: string
+    required: true
+  quantity:
+    type: integer
+    required: true

--- a/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/types/order.raml
+++ b/tests/JavascriptGeneratorBundle/Fixtures/raml/nullable-union/types/order.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0 DataType
+type: object
+displayName: Order object
+properties:
+  id:
+    type: string
+    required: true
+    description: Object id
+  note:
+    type: string | nil
+    required: true
+    description: Nullable union of a primitive type
+  discount:
+    type: number | nil
+    required: false
+    description: Nullable union on an optional property
+  line:
+    type: OrderLine | nil
+    required: false
+    description: Nullable union of a named type
+  tags:
+    type: array
+    items:
+      type: string | nil
+    required: false
+    description: Nullable union as an array item type
+  lines:
+    type: array
+    items:
+      type: OrderLine | nil
+    required: false
+    description: Nullable union of a named type as an array item type

--- a/tests/JavascriptGeneratorBundle/GeneratePackageCommandTest.php
+++ b/tests/JavascriptGeneratorBundle/GeneratePackageCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\JavascriptGeneratorBundle;
 
 use Doctrine\Common\Util\Inflector;
+use Paysera\Bundle\CodeGeneratorBundle\Exception\UnrecognizedTypeException;
 use Paysera\Bundle\JavascriptGeneratorBundle\Command\GeneratePackageCommand;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -90,6 +91,7 @@ class GeneratePackageCommandTest extends KernelTestCase
             ['user-info'],
             ['category'],
             ['account'],
+            ['nullable-union'],
             ['questionnaire'],
             ['issued-payment-card'],
             ['custom'],
@@ -112,6 +114,21 @@ class GeneratePackageCommandTest extends KernelTestCase
                 'platformVersion' => ">=18.0",
             ],
         ];
+    }
+
+    public function testGenerateCodeFailsForUnionOfValueTypes()
+    {
+        $apiName = 'genuine-union';
+        $this->removeTargetDir($apiName);
+
+        $this->expectException(UnrecognizedTypeException::class);
+        $this->expectExceptionMessage('Did not found defined type "string | boolean"');
+
+        $this->commandTester->execute([
+            'raml_file' => sprintf('%s/Fixtures/raml/%s/api.raml', __DIR__, $apiName),
+            'output_dir' => sprintf('%s/Fixtures/generated/%s', __DIR__, $apiName),
+            'client_name' => Inflector::classify($apiName) . 'Client',
+        ]);
     }
 
     /**

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/README.md
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/README.md
@@ -1,0 +1,60 @@
+
+## vendor-nullable-union-client
+
+Provides methods to manipulate `NullableUnionClient` API.
+It automatically authenticates all requests and maps required data structure for you.
+
+#### Usage
+
+This library provides `ClientFactory` class, which you should use to get the API client itself:
+
+```php
+use Paysera\Test\NullableUnionClient\ClientFactory;
+
+$clientFactory = new ClientFactory([
+    'base_url' => 'https://my-api.example.com/rest/v1/', // optional, in case you need a custom one.
+    'mac' => [                                          // use this, if API requires Mac authentication.
+        'mac_id' => 'my-mac-id',
+        'mac_secret' => 'my-mac-secret',
+    ],
+    'basic' => [                                        // use this, if API requires Basic authentication.
+        'username' => 'username',
+        'password' => 'password',
+    ],
+    'oauth' => [                                        // use this, if API requires OAuth v2 authentication.
+        'token' => [
+            'access_token' => 'my-access-token',
+            'refresh_token' => 'my-refresh-token',
+        ],
+    ],
+    // other configuration options, if needed
+]);
+
+$nullableUnionClient = $clientFactory->getNullableUnionClient();
+```
+
+Please use only one authentication mechanism, provided by `Vendor`.
+
+Now, that you have instance of `NullableUnionClient`, you can use following methods
+### Methods
+
+    
+Create order
+
+
+```php
+use Paysera\Test\NullableUnionClient\Entity as Entities;
+
+$order = new Entities\Order();
+
+$order->setId($id);
+$order->setNote($note);
+$order->setDiscount($discount);
+$order->setLine($line);
+$order->setTags($tags);
+$order->setLines($lines);
+    
+$result = $nullableUnionClient->createOrder($order);
+```
+---
+

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/composer.json
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "vendor/lib-nullable-union-client",
+    "description": "NullableUnionClient",
+    "version": "v1",
+    "autoload": {
+        "psr-4": {
+            "Paysera\\Test\\NullableUnionClient\\": "src"
+        }
+    },
+    "require": {
+        "php": ">=5.5",
+        "paysera/lib-rest-client-common": "^1.0 | ^2.5",
+        "fig/http-message-util": "^1.0"
+    },
+    "minimum-stability": "stable"
+}

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/ClientFactory.php
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/ClientFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Paysera\Test\NullableUnionClient;
+
+use Paysera\Component\RestClientCommon\Util\ClientFactoryAbstract;
+use Paysera\Component\RestClientCommon\Client\ApiClient;
+
+class ClientFactory extends ClientFactoryAbstract
+{
+    const DEFAULT_BASE_URL = 'https://my-api.example.com/rest/v1/';
+
+    protected $apiClient;
+
+    public function __construct($options)
+    {
+        if ($options instanceof ApiClient) {
+            $this->apiClient = $options;
+            return;
+        }
+
+        $defaultUrlParameters = [];
+        
+        $options['url_parameters'] = $this->resolveDefaultUrlParameters($defaultUrlParameters, $options);
+        $this->apiClient = $this->createApiClient($options);
+    }
+
+    public function getNullableUnionClient()
+    {
+        return new NullableUnionClient($this->apiClient);
+    }
+
+    private function resolveDefaultUrlParameters(array $defaults, array $options)
+    {
+        $params = [];
+        if (isset($options['url_parameters'])) {
+            $params = $options['url_parameters'];
+        }
+
+        return $params + $defaults;
+    }
+}

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/Entity/Order.php
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/Entity/Order.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Paysera\Test\NullableUnionClient\Entity;
+
+use Paysera\Component\RestClientCommon\Entity\Entity;
+
+class Order extends Entity
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->get('id');
+    }
+    /**
+     * @param string $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->set('id', $id);
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getNote()
+    {
+        return $this->get('note');
+    }
+    /**
+     * @param string $note
+     * @return $this
+     */
+    public function setNote($note)
+    {
+        $this->set('note', $note);
+        return $this;
+    }
+    /**
+     * @return string|null
+     */
+    public function getDiscount()
+    {
+        return $this->get('discount');
+    }
+    /**
+     * @param string $discount
+     * @return $this
+     */
+    public function setDiscount($discount)
+    {
+        $this->set('discount', $discount);
+        return $this;
+    }
+    /**
+     * @return OrderLine|null
+     */
+    public function getLine()
+    {
+        if ($this->get('line') === null) {
+            return null;
+        }
+        return (new OrderLine())->setDataByReference($this->getByReference('line'));
+    }
+    /**
+     * @param OrderLine $line
+     * @return $this
+     */
+    public function setLine(OrderLine $line)
+    {
+        $this->setByReference('line', $line->getDataByReference());
+        return $this;
+    }
+    /**
+     * @return string[]|null
+     */
+    public function getTags()
+    {
+        return $this->get('tags');
+    }
+    /**
+     * @param string[] $tags
+     * @return $this
+     */
+    public function setTags(array $tags)
+    {
+        $this->set('tags', $tags);
+        return $this;
+    }
+    /**
+     * @return OrderLine[]
+     */
+    public function getLines()
+    {
+        $items = $this->getByReference('lines');
+        if ($items === null) {
+            return [];
+        }
+
+        $list = [];
+        foreach($items as &$item) {
+            $list[] = (new OrderLine())->setDataByReference($item);
+        }
+
+        return $list;
+    }
+    /**
+     * @param OrderLine[] $lines
+     * @return $this
+     */
+    public function setLines(array $lines)
+    {
+        $data = [];
+        foreach($lines as $item) {
+            $data[] = $item->getDataByReference();
+        }
+        $this->setByReference('lines', $data);
+        return $this;
+    }
+}

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/Entity/OrderLine.php
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/Entity/OrderLine.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Paysera\Test\NullableUnionClient\Entity;
+
+use Paysera\Component\RestClientCommon\Entity\Entity;
+
+class OrderLine extends Entity
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSku()
+    {
+        return $this->get('sku');
+    }
+    /**
+     * @param string $sku
+     * @return $this
+     */
+    public function setSku($sku)
+    {
+        $this->set('sku', $sku);
+        return $this;
+    }
+    /**
+     * @return integer
+     */
+    public function getQuantity()
+    {
+        return $this->get('quantity');
+    }
+    /**
+     * @param integer $quantity
+     * @return $this
+     */
+    public function setQuantity($quantity)
+    {
+        $this->set('quantity', $quantity);
+        return $this;
+    }
+}

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/NullableUnionClient.php
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/expected/nullable-union/src/NullableUnionClient.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Paysera\Test\NullableUnionClient;
+
+use Paysera\Test\NullableUnionClient\Entity as Entities;
+use Fig\Http\Message\RequestMethodInterface;
+use Paysera\Component\RestClientCommon\Entity\Entity;
+use Paysera\Component\RestClientCommon\Client\ApiClient;
+
+class NullableUnionClient
+{
+    private $apiClient;
+
+    public function __construct(ApiClient $apiClient)
+    {
+        $this->apiClient = $apiClient;
+    }
+
+    public function withOptions(array $options)
+    {
+        return new NullableUnionClient($this->apiClient->withOptions($options));
+    }
+
+    /**
+     * Create order
+     * POST /orders
+     *
+     * @param Entities\Order $order
+     * @return Entities\Order
+     */
+    public function createOrder(Entities\Order $order)
+    {
+        $request = $this->apiClient->createRequest(
+            RequestMethodInterface::METHOD_POST,
+            'orders',
+            $order
+        );
+        $data = $this->apiClient->makeRequest($request);
+
+        return new Entities\Order($data);
+    }
+}

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/api.raml
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/api.raml
@@ -1,0 +1,27 @@
+#%RAML 1.0
+title: Nullable Union API
+version: v1
+baseUri: https://my-api.example.com/rest/v1
+mediaType: application/json
+protocols: [ HTTPS ]
+
+uses:
+  Paysera: ../__library/rest.raml
+
+types:
+  OrderLine: !include types/order-line.raml
+  Order: !include types/order.raml
+
+/orders:
+  post:
+    description: Create order
+    body:
+      application/json:
+        displayName: body
+        type: Order
+    responses:
+      200:
+        description: Item response
+        body:
+          application/json:
+            type: Order

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/types/order-line.raml
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/types/order-line.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+type: object
+displayName: Order Line
+properties:
+  sku:
+    type: string
+    required: true
+  quantity:
+    type: integer
+    required: true

--- a/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/types/order.raml
+++ b/tests/PhpGeneratorBundle/RestClient/Fixtures/raml/nullable-union/types/order.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0 DataType
+type: object
+displayName: Order object
+properties:
+  id:
+    type: string
+    required: true
+    description: Object id
+  note:
+    type: string | nil
+    required: true
+    description: Nullable union of a primitive type
+  discount:
+    type: number | nil
+    required: false
+    description: Nullable union on an optional property
+  line:
+    type: OrderLine | nil
+    required: false
+    description: Nullable union of a named type
+  tags:
+    type: array
+    items:
+      type: string | nil
+    required: false
+    description: Nullable union as an array item type
+  lines:
+    type: array
+    items:
+      type: OrderLine | nil
+    required: false
+    description: Nullable union of a named type as an array item type

--- a/tests/PhpGeneratorBundle/RestClient/GenerateRestClientCommandTest.php
+++ b/tests/PhpGeneratorBundle/RestClient/GenerateRestClientCommandTest.php
@@ -83,6 +83,7 @@ class GenerateRestClientCommandTest extends KernelTestCase
             ['account'],
             ['inheritance'],
             ['category'],
+            ['nullable-union'],
             ['transfer'],
             ['transfer-surveillance'],
             ['auth'],


### PR DESCRIPTION
## TR-7946

Follow-up to #135. That PR rescues two type categories the generator was discarding; this one removes the last type-resolution blocker, **nullable unions**.

Kept separate deliberately: #135 is a pair of narrow bug fixes, whereas this changes how a RAML construct is interpreted and deserves its own decision. Neither depends on the other, but `app-evpbank/public-transfers` needs both.

## The problem

`DefinitionValidator.php:83` refuses unions outright:

```php
if ($type instanceof UnionType) {
    throw new UnrecognizedTypeException('UnionType currently is not supported');
}
```

In practice you rarely see that message — a property typed `integer | nil` reaches `PropertyDefinitionBuilder` as the raw **string** `"integer | nil"`, is not recognised as a simple type, becomes a `TYPE_REFERENCE` to a type of that name, and fails later as:

```
Did not found defined type "integer | nil"
```

This was reported in **INV-257** (Apr 2024) and closed *"Won't Do"* in Feb 2025, so the behaviour is long-standing and known.

## Why it is worth fixing rather than declining again

`X | nil` is not really a union. It says a property is **present but may hold no value** — that is nullability, and RAML has no other way to express it. A union of two genuinely different shapes (`string | boolean`) is a different thing.

Counting every union in `paysera/api-spec`:

| Form | Occurrences |
|---|---|
| `string \| nil` | 12 |
| `integer \| nil` | 4 |
| `TransferTimelineInspection \| nil` | 2 |
| `TimelineMessageCode \| nil` | 2 |
| `datetime \| nil` | 1 |
| `boolean \| nil` | 1 |
| **`string \| boolean`** | **1** |

**21 of 22 are nullability.** Declining the whole feature to avoid the one hard case costs the other twenty-one — and those twenty-one are why `public-transfers` cannot be generated.

## What this PR does

`X | nil` collapses to `X`. Nothing is lost: every generated getter is `return this.get('key')`, which already yields `null` when the key is absent or null. Applies to property types and to array item types, and works for named types (`TimelineMessageCode | nil`) as well as primitives.

A union of two real types is **left exactly as it was**, so `string | boolean` still fails loudly rather than silently picking a side. That case has no single representation to generate and should stay a spec-authoring decision.

The change is confined to `PropertyDefinitionBuilder`, at the one point that already normalises a property's declared type.

## Test plan

### Regression — 27 fixture APIs, byte-identical output

Generated a JS client from **every** `api.raml` under `tests/` on unmodified `master`, then again with this change:

```
distinct APIs generated: 27 | byte-level differences: 0
```

No fixture currently uses a union, so this confirms the normalisation does not disturb any existing path.

### Forward — with #135, all type resolution now completes

Against the real `app-evpbank/public-transfers/api.raml`, with both branches applied and `paysera/api-spec!1789` (the missing example files):

| Stage | Result |
|---|---|
| master | `The file ../examples/transfer_create_payza.json does not exist or is unreadable` |
| + api-spec!1789 | `Did not found defined type "AccountingMetadata"` |
| + #135 | `Did not found defined type "string \| nil"` |
| + this PR | **type resolution completes** — no unresolved types remain |

### ⚠️ What I could not run

Two environment gaps on my side, both of which CI covers:

1. **PHPUnit was not run.** The PHP available to me has no `mbstring`, which PHPUnit requires, and the only other runtimes on hand are PHP 7.4 containers that cannot run this codebase. The 27-API comparison above is my substitute — please treat the unit suite as a required check.
2. **Generation of `public-transfers` still does not finish for me**, but no longer for any type reason: it now reaches template rendering and fails in `PayseraWordNetBundle` with `could not find driver`. My PHP reports `PDO::getAvailableDrivers()` → *none*, so the WordNet SQLite lookup used for verb detection in resource paths cannot open. That is my environment, not this change — the 27 fixture APIs generate fine because their paths do not trigger that lookup. **Anyone with `pdo_sqlite` should be able to complete the generation and confirm the resulting client.**

No fixture covers a union, so the new path has no golden-master coverage. I would rather add one than not — happy to, if you tell me which shape you want pinned.

## Context

`@paysera/public-transfers-client` is stuck at **4.13.0** and missing fields that shipped long ago (`vop_check.id` from CORE-5433, `vop_check.error_code` from TR-7778), because it has not been regenerable for a long time. Consumers read raw payload keys instead. This PR plus #135 plus api-spec!1789 are what change that.

Worth flagging: **PLT-1813** records an intent to replace this generator with OpenAPI Generator. If that is close, you may prefer to take #135 alone (two narrow fixes) and leave unions unsupported. This PR is written so that decision stays open.
